### PR TITLE
osx compatibility

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -10,9 +10,9 @@ function _add_to_config {
 # Link files
 basedir="$(dirname "$(realpath "$0")")"
 mkdir -p ~/.local/{bin,share/bash-completion/completions}
-ln -frs "${basedir}/gis" ~/.local/bin/gis
+ln -fs "${basedir}/gis" ~/.local/bin/gis
 echo "Created link '~/.local/bin/gis'"
-ln -frs "${basedir}/gis_completion.bash" ~/.local/share/bash-completion/completions/gis
+ln -fs "${basedir}/gis_completion.bash" ~/.local/share/bash-completion/completions/gis
 echo "Created link '~/.local/share/bash-completion/completions/gis'"
 
 # Modify config

--- a/install.zsh
+++ b/install.zsh
@@ -20,7 +20,7 @@ touch ~/.zshrc
 _add_to_config "export PATH=\$PATH:${HOME}/.local/bin"
 _add_to_config "autoload -U +X compinit && compinit"
 _add_to_config "autoload -U +X bashcompinit && bashcompinit"
-_add_to_config "source /home/${USER}/.local/share/bash-completion/completions/gis"
+_add_to_config "source ${HOME}/.local/share/bash-completion/completions/gis"
 echo "Updated '~/.zshrc'"
 
 echo


### PR DESCRIPTION
The `ln` version of osx does not have the `-r` option. I think that `-r` is not needed at all because the used path in the script are not relative. So it should be good to simply remove the `-r` option. I've tested it on my mac and it seems to work fine.

I've also changed the source path from `/home/${USER}/..` to `${HOME}/...`. OSX has the home path `/Users` instead of `/home`