### PR TITLE
fix: remove unsupported porcelain argument for git fetch

### DIFF
--- a/gis
+++ b/gis
@@ -49,7 +49,7 @@ function execute_git_command_on_list {
 
         # Execute 'fetch' or 'pull'
         if [ "$1" == "fetch" ]; then
-            output=$(git fetch --prune --all --porcelain &> >(sed "s/^/${text_bold}${text_blue}${repository_name}${text_reset} /"))
+            output=$(git fetch --prune --all &> >(sed "s/^/${text_bold}${text_blue}${repository_name}${text_reset} /"))
             [ "$?" != 0 ] && echo -e "${text_bold}${text_blue}${repository_name}${text_reset} ${text_bold}${text_red}ERROR${text_reset} while fetching\n${output}"
         elif [ "$1" == "pull" ]; then
             git pull --recurse-submodules &> >(sed "s/^/${text_bold}${text_magenta}${repository_name}${text_reset} /")


### PR DESCRIPTION
in my git version `git version 2.25.1`, `git fetch` does not support the `porcelain` argument