### PR TITLE
Add 'gis main' command to check out default branch in clean repos

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,6 +24,10 @@ It was inspired by [[https://wiki.ros.org/wstool][wstool]], [[https://github.com
     fetch  Execute 'git fetch --prune --all' for all found repositories
     pull   Execute 'git pull --recurse-submodules' for all found repositories
              which are behind upstream, includes 'gis fetch'
+    switch [BRANCH]
+           Check out BRANCH for all found repositories which have no
+           uncommitted changes. Defaults to 'default', which resolves to
+           the default branch of each repository.
 
   OPTIONS
     -j, --jobs  N     Limit 'fetch' and 'pull' commands to N parallel jobs

--- a/gis
+++ b/gis
@@ -25,6 +25,8 @@ COMMANDS
   fetch  Execute 'git fetch --prune --all' for all found repositories
   pull   Execute 'git pull --recurse-submodules' for all found repositories
          which are behind upstream, includes 'gis fetch'
+  main   Check out the default branch for all found repositories
+         which have no uncommitted changes
 
 OPTIONS
   -j, --jobs  N     Limit 'fetch' and 'pull' commands to N parallel jobs
@@ -61,6 +63,7 @@ function execute_git_command_on_list {
 jobs=0
 fetch=false
 pull=false
+checkout_main=false
 while (( "$#" )); do
     case "$1" in
         -j|--jobs)
@@ -100,6 +103,13 @@ while (( "$#" )); do
             ;;
         p*)
             error "Unsupported command ${text_bold}$1${text_reset}, did you mean ${text_bold}pull${text_reset}?"
+            ;;
+        main)
+            checkout_main=true
+            shift
+            ;;
+        m*)
+            error "Unsupported command ${text_bold}$1${text_reset}, did you mean ${text_bold}main${text_reset}?"
             ;;
         *)
             error "Unsupported command ${text_bold}$1${text_reset}"
@@ -225,6 +235,41 @@ if [ "$pull" == true ]; then
     # Wait for pulling of all lists
     for pid in "${pull_pids[@]}"; do
         wait "$pid"
+    done
+    echo
+fi
+
+# Check out default branch
+if [ "$checkout_main" == true ]; then
+    for dir in "${git_dirs[@]}"; do
+        cd "$dir" || continue
+        repository_name=$(basename "$dir")
+
+        # Determine default branch
+        if git symbolic-ref refs/remotes/origin/HEAD > /dev/null 2>&1; then
+            [[ $(git symbolic-ref refs/remotes/origin/HEAD) =~ refs/remotes/origin/(.*)$ ]] && origin_head="${BASH_REMATCH[1]}"
+        else
+            origin_head="main"
+        fi
+
+        # Skip if already on default branch
+        current_branch=$(git branch --show-current)
+        if [ "$current_branch" == "$origin_head" ]; then
+            continue
+        fi
+
+        # Skip if repo has local changes (staged or unstaged tracked files)
+        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+            echo "${text_bold}${text_yellow}${repository_name}${text_reset} has local changes, skipping checkout"
+            continue
+        fi
+
+        # Checkout default branch
+        if git checkout "$origin_head" 2>/dev/null; then
+            echo "${text_bold}${text_green}${repository_name}${text_reset} checked out ${text_bold}${origin_head}${text_reset}"
+        else
+            echo "${text_bold}${text_red}${repository_name}${text_reset} failed to check out ${text_bold}${origin_head}${text_reset}" >&2
+        fi
     done
     echo
 fi

--- a/gis
+++ b/gis
@@ -25,8 +25,10 @@ COMMANDS
   fetch  Execute 'git fetch --prune --all' for all found repositories
   pull   Execute 'git pull --recurse-submodules' for all found repositories
          which are behind upstream, includes 'gis fetch'
-  main   Check out the default branch for all found repositories
-         which have no uncommitted changes
+  switch [BRANCH]
+         Check out BRANCH for all found repositories which have no
+         uncommitted changes. Defaults to 'default', which resolves to
+         the default branch of each repository.
 
 OPTIONS
   -j, --jobs  N     Limit 'fetch' and 'pull' commands to N parallel jobs
@@ -63,7 +65,7 @@ function execute_git_command_on_list {
 jobs=0
 fetch=false
 pull=false
-checkout_main=false
+switch_branch=""
 while (( "$#" )); do
     case "$1" in
         -j|--jobs)
@@ -104,12 +106,17 @@ while (( "$#" )); do
         p*)
             error "Unsupported command ${text_bold}$1${text_reset}, did you mean ${text_bold}pull${text_reset}?"
             ;;
-        main)
-            checkout_main=true
-            shift
+        switch)
+            if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+                switch_branch="$2"
+                shift 2
+            else
+                switch_branch="default"
+                shift
+            fi
             ;;
-        m*)
-            error "Unsupported command ${text_bold}$1${text_reset}, did you mean ${text_bold}main${text_reset}?"
+        s*)
+            error "Unsupported command ${text_bold}$1${text_reset}, did you mean ${text_bold}switch${text_reset}?"
             ;;
         *)
             error "Unsupported command ${text_bold}$1${text_reset}"
@@ -239,36 +246,39 @@ if [ "$pull" == true ]; then
     echo
 fi
 
-# Check out default branch
-if [ "$checkout_main" == true ]; then
+# Switch branches
+if [ -n "$switch_branch" ]; then
     for dir in "${git_dirs[@]}"; do
         cd "$dir" || continue
         repository_name=$(basename "$dir")
 
-        # Determine default branch
-        if git symbolic-ref refs/remotes/origin/HEAD > /dev/null 2>&1; then
-            [[ $(git symbolic-ref refs/remotes/origin/HEAD) =~ refs/remotes/origin/(.*)$ ]] && origin_head="${BASH_REMATCH[1]}"
-        else
-            origin_head="main"
+        # Resolve 'default' to the default branch of the repository
+        branch="$switch_branch"
+        if [ "$branch" == "default" ]; then
+            if [[ $(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) =~ refs/remotes/origin/(.*)$ ]]; then
+                branch="${BASH_REMATCH[1]}"
+            else
+                echo "${text_bold}${text_yellow}${repository_name}${text_reset} has no default branch, skipping"
+                continue
+            fi
         fi
 
-        # Skip if already on default branch
-        current_branch=$(git branch --show-current)
-        if [ "$current_branch" == "$origin_head" ]; then
+        # Skip if already on the branch
+        if [ "$(git branch --show-current)" == "$branch" ]; then
             continue
         fi
 
-        # Skip if repo has local changes (staged or unstaged tracked files)
-        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-            echo "${text_bold}${text_yellow}${repository_name}${text_reset} has local changes, skipping checkout"
+        # Skip if repository has local changes (staged or unstaged tracked files)
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "${text_bold}${text_yellow}${repository_name}${text_reset} has local changes, skipping"
             continue
         fi
 
-        # Checkout default branch
-        if git checkout "$origin_head" 2>/dev/null; then
-            echo "${text_bold}${text_green}${repository_name}${text_reset} checked out ${text_bold}${origin_head}${text_reset}"
+        # Check out branch
+        if output=$(git checkout "$branch" 2>&1); then
+            echo "${text_bold}${text_green}${repository_name}${text_reset} checked out ${text_bold}${branch}${text_reset}"
         else
-            echo "${text_bold}${text_red}${repository_name}${text_reset} failed to check out ${text_bold}${origin_head}${text_reset}" >&2
+            echo "${text_bold}${text_red}${repository_name}${text_reset} failed to check out ${text_bold}${branch}${text_reset}: ${output}" >&2
         fi
     done
     echo

--- a/gis_completion.bash
+++ b/gis_completion.bash
@@ -1,6 +1,6 @@
 function _gis_completion {
     args=" -h -p --help --path "
-    commands=" fetch pull "
+    commands=" fetch main pull "
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
 

--- a/gis_completion.bash
+++ b/gis_completion.bash
@@ -1,8 +1,14 @@
 function _gis_completion {
     args=" -h -p --help --path "
-    commands=" fetch main pull "
+    commands=" fetch pull switch "
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    # Handle branch completion
+    if [[ ${prev} == switch ]]; then
+        COMPREPLY=( $(compgen -W "default $(git branch --format='%(refname:short)' 2> /dev/null)" -- "${cur}") )
+        return
+    fi
 
     # Handle path completion
     if [[ ${prev} == -p ]] || [[ ${prev} == --path ]]; then


### PR DESCRIPTION
## Summary

Adds a new `gis main` command that checks out the default branch across all discovered repositories.

- Only processes repos with no uncommitted changes (clean working tree)
- Skips repos already on the default branch (silent)
- Warns and skips repos with staged/unstaged modifications (yellow warning)
- Determines default branch via `git symbolic-ref refs/remotes/origin/HEAD` (fallback: `main`)
- Includes bash completion support